### PR TITLE
Fix wrong meta being extracted for Halo 1 indexed sound tags

### DIFF
--- a/meta/wrappers/halo1_map.py
+++ b/meta/wrappers/halo1_map.py
@@ -366,7 +366,7 @@ class Halo1Map(HaloMap):
 
         self.clear_map_cache()
 
-    def get_meta(self, tag_id, reextract=False, ignore_rsrc_sounds=False, **kw):
+    def get_meta(self, tag_id, reextract=False, ignore_rsrc_sounds=True, **kw):
         '''
         Takes a tag reference id as the sole argument.
         Returns that tags meta data as a parsed block.


### PR DESCRIPTION
Fixes https://github.com/MosesofEgypt/refinery/issues/12

Made a pull request because I am not sure if this is bad for any reason. But this would bring how we read Halo 1 sounds in line with how Halo 1 itself reads them.