### PR TITLE
Fix vertex normal normalization

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  - Fix extraction of node order for Halo 1 model/gbxmodel tags.
+ - Fix incorrect vertex normalization on the loading of JMS files.
  - Sped up JMS parsing using regex magic!
  - The model pipeline has a lot of repeated values moved into constants.
 

--- a/reclaimer/model/jms.py
+++ b/reclaimer/model/jms.py
@@ -299,13 +299,6 @@ class JmsVertex:
         self.other_weights = other_weights
         self.other_uvws = other_uvws
 
-        norm_len = self.norm_i**2 + self.norm_j**2 + self.norm_k**2
-        if norm_len > 0.0:
-            norm_len = norm_len**0.5
-            self.norm_i /= norm_len
-            self.norm_j /= norm_len
-            self.norm_k /= norm_len
-
     def __repr__(self):
         return """JmsVertex(node_0=%s,
     x=%s, y=%s, z=%s,

--- a/reclaimer/model/jms.py
+++ b/reclaimer/model/jms.py
@@ -281,9 +281,9 @@ class JmsVertex:
         self.pos_x = pos_x
         self.pos_y = pos_y
         self.pos_z = pos_z
-        self.norm_i = min(1.0, max(-1.0, norm_i))
-        self.norm_j = min(1.0, max(-1.0, norm_j))
-        self.norm_k = min(1.0, max(-1.0, norm_k))
+        self.norm_i = norm_i
+        self.norm_j = norm_j
+        self.norm_k = norm_k
         self.binorm_i = binorm_i
         self.binorm_j = binorm_j
         self.binorm_k = binorm_k
@@ -298,6 +298,13 @@ class JmsVertex:
         self.other_nodes = other_nodes
         self.other_weights = other_weights
         self.other_uvws = other_uvws
+
+        norm_len = self.norm_i**2 + self.norm_j**2 + self.norm_k**2
+        if norm_len > 0.0:
+            norm_len = norm_len**0.5
+            self.norm_i /= norm_len
+            self.norm_j /= norm_len
+            self.norm_k /= norm_len
 
     def __repr__(self):
         return """JmsVertex(node_0=%s,
@@ -1169,7 +1176,10 @@ def _read_jms_8200(jms_data, stop_at="", perm_name=None):
                 jms_model.verts[i] = JmsVertex(
                     parse_jm_int(jms_data[dat_i]),
                     parse_jm_float(jms_data[dat_i+1]), parse_jm_float(jms_data[dat_i+2]), parse_jm_float(jms_data[dat_i+3]),
-                    parse_jm_float(jms_data[dat_i+4]), parse_jm_float(jms_data[dat_i+5]), parse_jm_float(jms_data[dat_i+6]),
+                    # tool normalizes imported jms normals by clamping, so we have to clamp as well
+                    min(1.0, max(-1.0, parse_jm_float(jms_data[dat_i+4]))),
+                    min(1.0, max(-1.0, parse_jm_float(jms_data[dat_i+5]))),
+                    min(1.0, max(-1.0, parse_jm_float(jms_data[dat_i+6]))),
                     parse_jm_int(jms_data[dat_i+7]), parse_jm_float(jms_data[dat_i+8]),
                     parse_jm_float(jms_data[dat_i+9]), parse_jm_float(jms_data[dat_i+10]), parse_jm_float(jms_data[dat_i+11])
                     )
@@ -1355,8 +1365,13 @@ def _read_jms_8210(jms_data, stop_at=""):
             all_verts[:] = (None, ) * parse_jm_int(jms_data[dat_i])
             dat_i += 1
             for i in range(len(all_verts)):
-                x, y, z = parse_jm_float(jms_data[dat_i]),   parse_jm_float(jms_data[dat_i+1]),  parse_jm_float(jms_data[dat_i+2])
-                a, b, c = parse_jm_float(jms_data[dat_i+3]), parse_jm_float(jms_data[dat_i+4]),  parse_jm_float(jms_data[dat_i+5])
+                x, y, z = parse_jm_float(jms_data[dat_i]),   parse_jm_float(jms_data[dat_i+1]), parse_jm_float(jms_data[dat_i+2])
+                #a, b, c = parse_jm_float(jms_data[dat_i+3]), parse_jm_float(jms_data[dat_i+4]), parse_jm_float(jms_data[dat_i+5])
+
+                # tool normalizes imported jms normals in halo 1 by clamping, so I'm going to assume halo 2 does as well
+                a = min(1.0, max(-1.0, parse_jm_float(jms_data[dat_i+3])))
+                b = min(1.0, max(-1.0, parse_jm_float(jms_data[dat_i+4])))
+                c = min(1.0, max(-1.0, parse_jm_float(jms_data[dat_i+5])))
                 dat_i += 6
 
                 node_influences = [(-1, 0)] * parse_jm_int(jms_data[dat_i])

--- a/reclaimer/model/jms.py
+++ b/reclaimer/model/jms.py
@@ -281,9 +281,9 @@ class JmsVertex:
         self.pos_x = pos_x
         self.pos_y = pos_y
         self.pos_z = pos_z
-        self.norm_i = norm_i
-        self.norm_j = norm_j
-        self.norm_k = norm_k
+        self.norm_i = min(1.0, max(-1.0, norm_i))
+        self.norm_j = min(1.0, max(-1.0, norm_j))
+        self.norm_k = min(1.0, max(-1.0, norm_k))
         self.binorm_i = binorm_i
         self.binorm_j = binorm_j
         self.binorm_k = binorm_k
@@ -298,13 +298,6 @@ class JmsVertex:
         self.other_nodes = other_nodes
         self.other_weights = other_weights
         self.other_uvws = other_uvws
-
-        norm_len = self.norm_i**2 + self.norm_j**2 + self.norm_k**2
-        if norm_len > 0.0:
-            norm_len = norm_len**0.5
-            self.norm_i /= norm_len
-            self.norm_j /= norm_len
-            self.norm_k /= norm_len
 
     def __repr__(self):
         return """JmsVertex(node_0=%s,


### PR DESCRIPTION
Fixes vertex normalization on jms files being broken.

Old normalization:
![Screenshot_20200127_023818](https://user-images.githubusercontent.com/24233409/73311735-7efeb180-4227-11ea-8b01-4e94796b7a34.png)
No normalization:
![Screenshot_20200128_232600](https://user-images.githubusercontent.com/24233409/73311744-84f49280-4227-11ea-92fd-fb635425567b.png)
New normalization:
![Screenshot_20200128_233627](https://user-images.githubusercontent.com/24233409/73311760-8cb43700-4227-11ea-86c2-949f38438a6d.png)
