### PR TITLE
Fix OS actv definition assuming incorrect grenade struct index

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.4]
+### Changed
+ - Fix actor_variant struct being incorrect for open sauce tag types.
+
 ## [2.9.3]
 ### Changed
  - Add actor type to actor_variant to support MCC scoring.

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.9.4]
 ### Changed
- - Fix actor_variant struct being incorrect for open sauce tag types.
+ - Fix actor_variant struct being incorrect for open sauce tag set.
+ - Remove magic numbers from os\_hek actor\_variant definition to avoid it breaking in the future.
 
 ## [2.9.3]
 ### Changed

--- a/reclaimer/__init__.py
+++ b/reclaimer/__init__.py
@@ -12,8 +12,8 @@
 # ##############
 __author__ = "Sigmmma"
 #           YYYY.MM.DD
-__date__ = "2020.05.22"
-__version__ = (2, 9, 3)
+__date__ = "2020.06.13"
+__version__ = (2, 9, 4)
 __website__ = "https://github.com/Sigmmma/reclaimer"
 __all__ = (
     "animation", "bitmaps", "h2", "h3", "halo_script", "hek", "meta", "misc",

--- a/reclaimer/hek/defs/actv.py
+++ b/reclaimer/hek/defs/actv.py
@@ -17,6 +17,31 @@ change_color = Struct("change_color",
     SIZE=32
     )
 
+actv_grenades = Struct("grenades",
+    Pad(8),
+    SEnum16("grenade_type", *grenade_types),
+    SEnum16("trajectory_type",
+        "toss",
+        "lob",
+        "bounce",
+        ),
+    SEnum16("grenade_stimulus",
+        "never",
+        "visible_target",
+        "seek_cover",
+        ),
+    SInt16("minimum_enemy_count"),
+    float_wu("enemy_radius"),
+
+    Pad(4),
+    float_wu_sec("grenade_velocity", UNIT_SCALE=per_sec_unit_scale),
+    from_to_wu("grenade_ranges"),
+    float_wu("collateral_damage_radius"),
+    float_zero_to_one("grenade_chance"),
+    float_sec("grenade_check_time", UNIT_SCALE=sec_unit_scale),
+    float_sec("encounter_grenade_timeout", UNIT_SCALE=sec_unit_scale)
+    )
+
 actv_body = Struct("tagdata",
     Bool32('flags',
         "can_shoot_while_flying",
@@ -139,30 +164,7 @@ actv_body = Struct("tagdata",
         ),
 
     #Grenades
-    Struct("grenades",
-        Pad(8),
-        SEnum16("grenade_type", *grenade_types),
-        SEnum16("trajectory_type",
-            "toss",
-            "lob",
-            "bounce",
-            ),
-        SEnum16("grenade_stimulus",
-            "never",
-            "visible_target",
-            "seek_cover",
-            ),
-        SInt16("minimum_enemy_count"),
-        float_wu("enemy_radius"),
-
-        Pad(4),
-        float_wu_sec("grenade_velocity", UNIT_SCALE=per_sec_unit_scale),
-        from_to_wu("grenade_ranges"),
-        float_wu("collateral_damage_radius"),
-        float_zero_to_one("grenade_chance"),
-        float_sec("grenade_check_time", UNIT_SCALE=sec_unit_scale),
-        float_sec("encounter_grenade_timeout", UNIT_SCALE=sec_unit_scale)
-        ),
+    actv_grenades,
 
     #Items
     Struct("items",

--- a/reclaimer/os_hek/defs/actv.py
+++ b/reclaimer/os_hek/defs/actv.py
@@ -11,13 +11,13 @@ from ...hek.defs.actv import *
 
 # TODO use some supyr trickery to make this nicer.
 
-# grenades descriptor index in actv_body is 10
+# grenades descriptor index in actv_body is 11
 # grenade_type descriptor index in grenades_desc is 1
 
 # replace the grenade_type descriptor with one
 # that uses open sauce's extra grenade slots
 actv_body = dict(actv_body)
-grenades_desc = actv_body[10] = dict(actv_body[10])
+grenades_desc = actv_body[11] = dict(actv_body[11])
 grenades_desc[1] = SEnum16("grenade_type", *grenade_types_os)
 
 def get():

--- a/reclaimer/os_hek/defs/actv.py
+++ b/reclaimer/os_hek/defs/actv.py
@@ -7,18 +7,21 @@
 # See LICENSE for more information.
 #
 
+from supyr_struct.util import desc_variant
+
 from ...hek.defs.actv import *
 
-# TODO use some supyr trickery to make this nicer.
+# Create opensauce variant of grenade descriptor.
 
-# grenades descriptor index in actv_body is 11
-# grenade_type descriptor index in grenades_desc is 1
+os_actv_grenades = desc_variant(actv_grenades,
+    ("grenade_type", SEnum16("grenade_type", *grenade_types_os)),
+)
 
-# replace the grenade_type descriptor with one
-# that uses open sauce's extra grenade slots
-actv_body = dict(actv_body)
-grenades_desc = actv_body[11] = dict(actv_body[11])
-grenades_desc[1] = SEnum16("grenade_type", *grenade_types_os)
+# Create os variant of actv descritor using the new grenade descriptor.
+
+actv_body = desc_variant(actv_body,
+    ("grenades", os_actv_grenades),
+)
 
 def get():
     return actv_def

--- a/reclaimer/os_hek/defs/actv.py
+++ b/reclaimer/os_hek/defs/actv.py
@@ -17,7 +17,7 @@ os_actv_grenades = desc_variant(actv_grenades,
     ("grenade_type", SEnum16("grenade_type", *grenade_types_os)),
 )
 
-# Create os variant of actv descritor using the new grenade descriptor.
+# Create os variant of actv descriptor using the new grenade descriptor.
 
 actv_body = desc_variant(actv_body,
     ("grenades", os_actv_grenades),


### PR DESCRIPTION
This needs to be approved asap. The open sauce definitions(the ones refinery uses) were never updated to know which index the grenade struct is at. There are other places in the code that assume explicit indices. In the long term, these should be updated to use desc_variant in supyr, as it replaces based on field name rather than index.