### PR TITLE
Safeguards against corrupt tags

### DIFF
--- a/reclaimer/common_descs.py
+++ b/reclaimer/common_descs.py
@@ -60,7 +60,7 @@ def reflexive(name, substruct, max_count=MAX_REFLEXIVE_COUNT, *names, **desc):
     '''This function serves to macro the creation of a reflexive'''
     desc.update(
         INCLUDE=reflexive_struct,
-        STEPTREE=Array(name + "_array",
+        STEPTREE=ReflexiveArray(name + "_array",
             SIZE=".size", MAX=max_count,
             SUB_STRUCT=substruct, WIDGET=ReflexiveFrame
             ),

--- a/reclaimer/constants.py
+++ b/reclaimer/constants.py
@@ -200,6 +200,10 @@ CUBEMAP_PADDING = 128
 #indices, though I have seen some open sauce stuff go over 180,000.
 MAX_REFLEXIVE_COUNT = 2**31-1
 
+# this numbers was taken from crawling the tag
+# definitions for the highest value among them
+SANE_MAX_REFLEXIVE_COUNT = 0x800000   # sbsp.detail_objects.counts
+
 MAX_TAG_PATH_LEN = 254
 
 # maps tag class four character codes(fccs) in

--- a/reclaimer/constants.py
+++ b/reclaimer/constants.py
@@ -196,8 +196,7 @@ BITMAP_PADDING = 512
 #each sub-bitmap(cubemap face) must be a multiple of 128 bytes
 CUBEMAP_PADDING = 128
 
-#I cant imagine Halo allowing any one field even close to this many
-#indices, though I have seen some open sauce stuff go over 180,000.
+# max value a reflexive count is theoretically allowed to be
 MAX_REFLEXIVE_COUNT = 2**31-1
 
 # this numbers was taken from crawling the tag

--- a/reclaimer/field_type_methods.py
+++ b/reclaimer/field_type_methods.py
@@ -284,6 +284,27 @@ def reflexive_parser(self, desc, node=None, parent=None, attr_index=None,
         raise e
 
 
+def reflexive_array_parser(self, desc, node=None, parent=None, attr_index=None,
+                           rawdata=None, root_offset=0, offset=0, **kwargs):
+    '''
+    Variant of array_parser which ensures there is enough rawdata to parse the array.
+    '''
+    try:
+        if parent is not None and rawdata is not None:
+            if root_offset + offset + parent.size * desc['SUB_STRUCT'][SIZE] > len(rawdata):
+                raise ValueError("Reflexive size is out of bounds of input stream.")
+            
+        return array_parser(
+            self, desc, node, parent, attr_index, rawdata, root_offset, offset, **kwargs
+            )
+    except Exception as e:
+        e = format_parse_error(e, field_type=self, desc=desc,
+                               parent=parent, attr_index=attr_index,
+                               offset=offset, root_offset=root_offset,
+                               buffer=rawdata, **kwargs)
+        raise e
+
+
 def rawdata_ref_parser(self, desc, node=None, parent=None, attr_index=None,
                        rawdata=None, root_offset=0, offset=0, **kwargs):
     try:

--- a/reclaimer/field_type_methods.py
+++ b/reclaimer/field_type_methods.py
@@ -229,19 +229,26 @@ def reflexive_parser(self, desc, node=None, parent=None, attr_index=None,
         s_desc = desc.get(STEPTREE)
         if s_desc:
             pointer_converter = kwargs.get('map_pointer_converter')
+            safe_mode = kwargs.get("safe_mode") and not desc.get(IGNORE_SAFE_MODE)
+
             if pointer_converter is not None:
                 file_ptr = pointer_converter.v_ptr_to_f_ptr(node[1])
-                if kwargs.get("safe_mode") and not (
-                        desc.get(IGNORE_SAFE_MODE) or s_desc.get(IGNORE_SAFE_MODE)):
+                if safe_mode:
                     # make sure the reflexive sizes are less than or equal to
                     # the max number of entries allowed in the reflexive
-                    node[0] = max(0, min(node[0], s_desc.get(MAX, node[0])))
+                    node[0] = max(0, min(node[0], s_desc.get(
+                        MAX, SANE_MAX_REFLEXIVE_COUNT)))
 
                 if (file_ptr < 0 or file_ptr +
                     node[0]*s_desc[SUB_STRUCT].get(SIZE, 0) > len(rawdata)):
                     # the reflexive is corrupt for some reason
                     #    (ex: bad hek+ extraction)
                     node[0] = node[1] = 0
+
+            elif node[0] > SANE_MAX_REFLEXIVE_COUNT or (
+                    safe_mode and node[0] > s_desc.get(MAX, node[0])
+                    ):
+                raise ValueError("Reflexive size is above highest allowed value.")
 
             if not node[0]:
                 # reflexive is empty. no need to provide rawdata
@@ -298,11 +305,13 @@ def rawdata_ref_parser(self, desc, node=None, parent=None, attr_index=None,
         s_desc = desc.get(STEPTREE)
         if s_desc:
             pointer_converter = kwargs.get("map_pointer_converter")
+            safe_mode = kwargs.get("safe_mode") and not s_desc.get(IGNORE_SAFE_MODE)
 
-            if pointer_converter is not None:
-                if kwargs.get("safe_mode") and not (
-                        desc.get(IGNORE_SAFE_MODE) or s_desc.get(IGNORE_SAFE_MODE)):
+            if safe_mode:
+                if pointer_converter is not None:
                     node[0] = max(0, min(node[0], s_desc.get(MAX, node[0])))
+                elif node[0] > s_desc.get(MAX, node[0]):
+                    raise ValueError("Rawdata size is above highest allowed value.")
 
             if kwargs.get("parsing_resource"):
                 # parsing JUST metadata from a resource cache

--- a/reclaimer/field_type_methods.py
+++ b/reclaimer/field_type_methods.py
@@ -229,7 +229,7 @@ def reflexive_parser(self, desc, node=None, parent=None, attr_index=None,
         s_desc = desc.get(STEPTREE)
         if s_desc:
             pointer_converter = kwargs.get('map_pointer_converter')
-            safe_mode = kwargs.get("safe_mode") and not desc.get(IGNORE_SAFE_MODE)
+            safe_mode = kwargs.get("safe_mode", True) and not desc.get(IGNORE_SAFE_MODE)
 
             if pointer_converter is not None:
                 file_ptr = pointer_converter.v_ptr_to_f_ptr(node[1])
@@ -305,7 +305,7 @@ def rawdata_ref_parser(self, desc, node=None, parent=None, attr_index=None,
         s_desc = desc.get(STEPTREE)
         if s_desc:
             pointer_converter = kwargs.get("map_pointer_converter")
-            safe_mode = kwargs.get("safe_mode") and not s_desc.get(IGNORE_SAFE_MODE)
+            safe_mode = kwargs.get("safe_mode", True) and not s_desc.get(IGNORE_SAFE_MODE)
 
             if safe_mode:
                 if pointer_converter is not None:

--- a/reclaimer/field_types.py
+++ b/reclaimer/field_types.py
@@ -12,11 +12,14 @@ from struct import unpack
 from supyr_struct.defs import sanitizers
 from supyr_struct.field_types import *
 from supyr_struct.blocks import EnumBlock
-from reclaimer.field_type_methods import encode_tag_ref_str,\
-     tag_ref_str_sizecalc, tag_ref_str_parser, tag_ref_str_serializer,\
-     decode_raw_string, decode_string, decoder_wrapper, encoder_wrapper,\
-     tag_cstring_parser, rawdata_ref_parser, reflexive_parser, encode_string,\
-     utf_sizecalc, delim_utf_sizecalc, sizecalc_wrapper, len_sizecalc
+from reclaimer.field_type_methods import (
+    encode_tag_ref_str, tag_ref_str_sizecalc, tag_ref_str_parser,
+    tag_ref_str_serializer, decode_raw_string, decode_string,
+    decoder_wrapper, encoder_wrapper, tag_cstring_parser,
+    rawdata_ref_parser, reflexive_parser, encode_string,
+    utf_sizecalc, delim_utf_sizecalc, sizecalc_wrapper, len_sizecalc,
+    reflexive_array_parser,
+    )
 
 
 '''These are varients of the standard FieldTypes that have been
@@ -71,6 +74,10 @@ RawdataRef   = FieldType(base=Struct,  name="RawdataRef", parser=rawdata_ref_par
 Reflexive    = FieldType(base=QStruct, name="Reflexive", parser=reflexive_parser)
 RawReflexive = FieldType(base=Reflexive, name="RawReflexive")
 TagRef       = FieldType(base=Struct, name="TagRef")
+
+ReflexiveArray = FieldType(
+    base=Array, name="ReflexiveArray", parser=reflexive_array_parser
+    )
 
 ZoneAsset = FieldType(base=QStruct, name="ZoneAsset")
 StringID  = FieldType(base=QStruct, name="StringID")

--- a/reclaimer/meta/wrappers/halo1_map.py
+++ b/reclaimer/meta/wrappers/halo1_map.py
@@ -436,7 +436,7 @@ class Halo1Map(HaloMap):
             if rsrc_map is None:
                 return
 
-            meta = rsrc_map.get_meta(tag_id)
+            meta = rsrc_map.get_meta(tag_id, **kw)
             if tag_cls == "snd!":
                 # since we're reading the resource tag from the perspective of
                 # the map referencing it, we have more accurate information

--- a/reclaimer/meta/wrappers/halo1_rsrc_map.py
+++ b/reclaimer/meta/wrappers/halo1_rsrc_map.py
@@ -244,6 +244,7 @@ class Halo1RsrcMap(HaloMap):
                 desc, parent=block, attr_index=0, rawdata=self.map_data,
                 tag_index_manager=self.snd_rsrc_tag_index_manager,
                 tag_cls=tag_cls, root_offset=tag_index_ref.meta_offset,
+                safe_mode=not kw.get("disable_safe_mode"),
                 indexed=True, **kwargs)
             FieldType.force_normal()
 


### PR DESCRIPTION
Implements requested safeguards in reclaimer to fail early if the tag appears corrupt(extreme memory bloat likely to occur).