### PR TITLE
Fix tag reflexive truncation

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.9.11]
 ### Changed
- - Change SANE_MAX_REFLEXIVE_COUNT from 0x800000 to 2^16-1
+ - Change SANE_MAX_REFLEXIVE_COUNT from 0x800000 to 0xFFFE
  - Change code that decides what max size to use from finding the minimum between
    max entries for that reflexive and SANE_MAX_REFLEXIVE_COUNT to finding the maximum.
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.11]
+### Changed
+ - Change SANE_MAX_REFLEXIVE_COUNT from 0x800000 to 2^16-1
+ - Change code that decides what max size to use from finding the minimum between
+   max entries for that reflexive and SANE_MAX_REFLEXIVE_COUNT to finding the maximum.
+
 ## [2.9.10]
 ### Changed
  - Add missing "inhibits weapon attack" field in model_collision definition.

--- a/reclaimer/__init__.py
+++ b/reclaimer/__init__.py
@@ -12,8 +12,8 @@
 # ##############
 __author__ = "Sigmmma"
 #           YYYY.MM.DD
-__date__ = "2020.10.30"
-__version__ = (2, 9, 10)
+__date__ = "2020.10.31"
+__version__ = (2, 9, 11)
 __website__ = "https://github.com/Sigmmma/reclaimer"
 __all__ = (
     "animation", "bitmaps", "h2", "h3", "halo_script", "hek", "meta", "misc",

--- a/reclaimer/constants.py
+++ b/reclaimer/constants.py
@@ -201,7 +201,7 @@ MAX_REFLEXIVE_COUNT = 2**31-1
 
 # this number was taken by seeing what the highest indexable reflexive number
 # is.
-SANE_MAX_REFLEXIVE_COUNT = 2^16-1
+SANE_MAX_REFLEXIVE_COUNT = 2**16-1
 
 MAX_TAG_PATH_LEN = 254
 

--- a/reclaimer/constants.py
+++ b/reclaimer/constants.py
@@ -199,9 +199,9 @@ CUBEMAP_PADDING = 128
 # max value a reflexive count is theoretically allowed to be
 MAX_REFLEXIVE_COUNT = 2**31-1
 
-# this numbers was taken from crawling the tag
-# definitions for the highest value among them
-SANE_MAX_REFLEXIVE_COUNT = 0x800000   # sbsp.detail_objects.counts
+# this number was taken by seeing what the highest indexable reflexive number
+# is.
+SANE_MAX_REFLEXIVE_COUNT = 2^16-1
 
 MAX_TAG_PATH_LEN = 254
 

--- a/reclaimer/constants.py
+++ b/reclaimer/constants.py
@@ -201,7 +201,7 @@ MAX_REFLEXIVE_COUNT = 2**31-1
 
 # this number was taken by seeing what the highest indexable reflexive number
 # is.
-SANE_MAX_REFLEXIVE_COUNT = 2**16-1
+SANE_MAX_REFLEXIVE_COUNT = 0xFFFE
 
 MAX_TAG_PATH_LEN = 254
 

--- a/reclaimer/field_type_methods.py
+++ b/reclaimer/field_type_methods.py
@@ -234,9 +234,8 @@ def reflexive_parser(self, desc, node=None, parent=None, attr_index=None,
             if pointer_converter is not None:
                 file_ptr = pointer_converter.v_ptr_to_f_ptr(node[1])
                 if safe_mode:
-                    # make sure the reflexive sizes are less than or equal to
-                    # the max number of entries allowed in the reflexive
-                    node[0] = max(0, min(node[0], s_desc.get(
+                    # make sure the reflexive sizes are within sane bounds.
+                    node[0] = max(0, max(node[0], s_desc.get(
                         MAX, SANE_MAX_REFLEXIVE_COUNT)))
 
                 if (file_ptr < 0 or file_ptr +


### PR DESCRIPTION
This globally fixes the issue where some tags are extracted improperly having reflexive elements truncated to default limits. Example situations where these issues can occur is when using child scenarios.

The sane max count was picked as the max 16 bit indexable number. The logic was changed to instead of picking the lowest between the max sane and the actual max to pick the highest.